### PR TITLE
fixed linkset options being overridden

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -283,7 +283,7 @@ const plugin = options => {
       if (!html(file)) return;
       if (data.permalink === false) return;
 
-      const linkset = Object.assign({}, findLinkset(data), defaultLinkset);
+      const linkset = Object.assign({}, defaultLinkset, findLinkset(data));
       debug('applying pattern: %s to file: %s', linkset.pattern, file);
 
       let ppath = replace(linkset.pattern, data, linkset) || resolve(file);


### PR DESCRIPTION
### What has changed?

Linkset options which where also defined in the default set were always overridden. This pull request fixes this by taking the default set and then applying the custom matched link set.

### Level of change

- Bug fix

---
For **Added functionality** and **API changes** make sure the documentation has been updated accordingly.
